### PR TITLE
Resolve module errors and add script to generate docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+sampleapp/viewbrowser/view_browser_exec
+sampleapp/viewbrowser/deployment/view_browser_exec
+sampleapp/viewbrowser/deployment/view-browser:latest
+

--- a/sampleapp/README.md
+++ b/sampleapp/README.md
@@ -21,11 +21,14 @@ After installing GO, use `go get` to install the sample app: viewbrowser:
 
 ```go get github.com/cohesity/cohesity-appspec/sampleapp/viewbrowser```
 
-```If this does not work. Follow below steps```
-```1. go mod init view_browser_exec (Run this command in cohesity-appspec/sampleapp/viewbrowser )```
-```2. go build .```
-```3. Copy generated view_browser_exec binary file to deployment folder ```
-
+If this does not work. Follow below steps
+```
+(Run this command in cohesity-appspec/sampleapp/viewbrowser). Do not change module name.
+1. go mod init github.com/cohesity/cohesity-appspec/sampleapp/viewbrowser
+2. go build .
+3. Copy generated viewbrowser binary file to deployment folder
+4. Change the name of the binary inside deployment to view_browser_exec
+```
 
 
 

--- a/sampleapp/README.md
+++ b/sampleapp/README.md
@@ -30,10 +30,20 @@ If this does not work. Follow below steps
 4. Change the name of the binary inside deployment to view_browser_exec
 ```
 
-
-
 This will also get all the dependencies including Cohesity App and 
 Management Go SDKs.
+
+## Modifying and Updating the App
+If you make any changes to the source code, you can rebuild the binaries and docker image with the script `install.sh` inside viewbrowser folder.
+
+Even if you are building it for the first time, the script would generate the docker images for you. To run the script, 
+
+```
+1. Modify the top line of the script to reflect the correct path of the view browser app.
+2. Make the script executable using "chmod +x script.sh". (Only needed once).
+3. Run the script using "./install.sh" from the corresponding folder.
+4. Your final docker image would then be saved inside the "deployment" folder by the name "view-browser:latest"
+```
 
 ## Container Environment Parameters
 The App Container Environment has the following parameters initialized by 

--- a/sampleapp/README.md
+++ b/sampleapp/README.md
@@ -17,17 +17,10 @@ and [Management](https://github.com/cohesity/management-sdk-go) Golang SDKs.
 In order to successfully build and run Sample App, you are required to 
 have the following setup in your system: [Golang](https://golang.org/doc/install)
 
-After installing GO, use `go get` to install the sample app: viewbrowser:
-
-```go get github.com/cohesity/cohesity-appspec/sampleapp/viewbrowser```
-
-If this does not work. Follow below steps
+To install the app, follow below steps
 ```
-(Run this command in cohesity-appspec/sampleapp/viewbrowser). Do not change module name.
-1. go mod init github.com/cohesity/cohesity-appspec/sampleapp/viewbrowser
-2. go build .
-3. Copy generated viewbrowser binary file to deployment folder
-4. Change the name of the binary inside deployment to view_browser_exec
+1. go build -o view_browser_exec. (Execute this command from the viewbrowser folder)
+2. Copy generated view_browser_exec binary file to deployment folder
 ```
 
 This will also get all the dependencies including Cohesity App and 

--- a/sampleapp/viewbrowser/go.mod
+++ b/sampleapp/viewbrowser/go.mod
@@ -1,0 +1,13 @@
+module github.com/cohesity/cohesity-appspec/sampleapp/viewbrowser
+
+go 1.12
+
+require (
+	github.com/apimatic/form v0.0.0-20160503070951-57699fab37f4 // indirect
+	github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 // indirect
+	github.com/cohesity/app-sdk-go v0.0.0-20190722230114-5dbb9337cc19
+	github.com/cohesity/management-sdk-go v0.0.0-20210611183926-ee285b549580
+	github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab
+	github.com/golang/glog v1.0.0
+	github.com/satori/go.uuid v1.2.0 // indirect
+)

--- a/sampleapp/viewbrowser/go.sum
+++ b/sampleapp/viewbrowser/go.sum
@@ -1,0 +1,14 @@
+github.com/apimatic/form v0.0.0-20160503070951-57699fab37f4 h1:H14RNDBXMLIy2vML4QC8jzzi0hwiiiq3w4n8ePxXDY4=
+github.com/apimatic/form v0.0.0-20160503070951-57699fab37f4/go.mod h1:UjJSEhRLclWeKGd5hpGAljQDx/lSLGK0rW8PM50RPCM=
+github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0 h1:sDMmm+q/3+BukdIpxwO365v/Rbspp2Nt5XntgQRXq8Q=
+github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
+github.com/cohesity/app-sdk-go v0.0.0-20190722230114-5dbb9337cc19 h1:3Wk/wxPgBbrx+a9TWS/HKMnIf4SopRpjHc6WSVZGHhI=
+github.com/cohesity/app-sdk-go v0.0.0-20190722230114-5dbb9337cc19/go.mod h1:xQlEJfpO+WnAvNpgFdp3Ppmdynuaix2H9X+/lKg6lb8=
+github.com/cohesity/management-sdk-go v0.0.0-20210611183926-ee285b549580 h1:r/UbLeGo/EvOaN0ZTI6FKgZY5MjnKTwPUSkJwgGUPc8=
+github.com/cohesity/management-sdk-go v0.0.0-20210611183926-ee285b549580/go.mod h1:6x1vvGzN4NCabZQRpYjS72BNjqtDWGCbklGrGbmhAXQ=
+github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab h1:xveKWz2iaueeTaUgdetzel+U7exyigDYBryyVfV/rZk=
+github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
+github.com/golang/glog v1.0.0 h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=
+github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
+github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
+github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=

--- a/sampleapp/viewbrowser/install.sh
+++ b/sampleapp/viewbrowser/install.sh
@@ -1,0 +1,34 @@
+# Change the directory to the required location
+cd ~/workspace/cohesity-appsec-new/cohesity-appspec/sampleapp/viewbrowser  
+echo "Switched to the View Browser Directory"
+
+rm go.mod go.sum viewbrowser
+echo "Removed the existing binaries and modules"
+
+go mod init github.com/cohesity/cohesity-appspec/sampleapp/viewbrowser
+echo "Created Go modules"
+
+go get -v 
+echo "Downloaded all dependencies"
+
+go build .
+echo "Built the Go binary"
+
+cp viewbrowser deployment/view_browser_exec
+echo "Copied the binary to the view browser folder"
+
+cd deployment
+echo "Swtiched to the deployment folder"
+
+docker image rm view-browser:latest
+echo "Removed existing docker images"
+
+docker build -t view-browser .
+echo "Docker new image build complete"
+
+touch view-browser:latest
+docker save view-browser -o view-browser:latest
+echo "Docker image saved"
+
+docker images
+echo "Finished"

--- a/sampleapp/viewbrowser/install.sh
+++ b/sampleapp/viewbrowser/install.sh
@@ -1,20 +1,11 @@
 # Change the directory to the required location
-cd ~/workspace/cohesity-appsec-new/cohesity-appspec/sampleapp/viewbrowser  
+cd ~/temp/cohesity-appspec/sampleapp/viewbrowser  
 echo "Switched to the View Browser Directory"
 
-rm go.mod go.sum viewbrowser
-echo "Removed the existing binaries and modules"
-
-go mod init github.com/cohesity/cohesity-appspec/sampleapp/viewbrowser
-echo "Created Go modules"
-
-go get -v 
-echo "Downloaded all dependencies"
-
-go build .
+go build -o view_browser_exec .
 echo "Built the Go binary"
 
-cp viewbrowser deployment/view_browser_exec
+cp view_browser_exec deployment/view_browser_exec
 echo "Copied the binary to the view browser folder"
 
 cd deployment


### PR DESCRIPTION
At the moment, if you make changes to the source code of the app and rebuild the docker image using previous instructions, the changes won't be reflected. This is because there were module name mismatch due to which it always downloaded old source code from Github.

Also added a script to automate the process of generating an updated docker image whenever you make changes to the code.